### PR TITLE
feat: basic functionality

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    [
+      "@babel/env", {
+        "targets": {
+          "node": "10.0"
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "extends": [
+    "@keboola/node"
+  ],
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "no-underscore-dangle": ["error", {
+      "allow": ["__"]
+    }]
+  },
+  "env": {
+    "node": true,
+    "mocha": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.idea
+node_modules
+jspm_packages
+.serverless
+.webpack
+.env
+.docker
+jre-*
+jdk-*
+.DS_Store
+certs
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+
+node_js:
+  - node
+
+before_script:
+  - yarn install
+
+script:
+  - yarn lint
+  - yarn tests
+
+#deploy:
+#  skip_cleanup: true
+#  provider: npm
+#  email: $NPM_EMAIL
+#  api_key: $NPM_TOKEN
+#  on:
+#    tags: true
+#    repo: keboola/middy-error-logger
+#    branch: master

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2017 Keboola
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2017 Keboola
+Copyright (c) 2019 Keboola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "oauth-api",
+  "author": "Miroslav Cillik <miro@keboola.com>",
+  "license": "MIT",
+  "version": "1.0.0",
+  "description": "Keboola OAuth API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/keboola/oauth-api.git"
+  },
+  "dependencies": {
+    "@babel/polyfill": "^7.4.4",
+    "ramda": "^0.26.1",
+    "unexpected": "^11.7.0"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.5.5",
+    "@babel/core": "^7.5.5",
+    "@babel/plugin-transform-runtime": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@babel/register": "^7.5.5",
+    "@babel/runtime": "^7.5.5",
+    "middy": "^0.28.4",
+    "mocha": "^6.2.0",
+    "sinon": "^7.3.2"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint src tests",
+    "tests": "mocha --timeout 0 --require @babel/register --full-trace tests",
+    "babel": "./node_modules/.bin/babel src --out-dir dist"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "@babel/preset-env": "^7.5.5",
     "@babel/register": "^7.5.5",
     "@babel/runtime": "^7.5.5",
+    "@keboola/eslint-config-node": "^1.0.1",
+    "eslint": "^6.1.0",
+    "eslint-plugin-import": "^2.18.2",
     "middy": "^0.28.4",
     "mocha": "^6.2.0",
     "sinon": "^7.3.2"

--- a/src/requestLoggerMiddleware.js
+++ b/src/requestLoggerMiddleware.js
@@ -1,7 +1,6 @@
 import * as R from 'ramda';
 
 export default (config) => {
-
   const defaults = {
     logger: console.log,
     filter: {
@@ -21,13 +20,12 @@ export default (config) => {
 
   return ({
     before: (handler, next) => {
-      const event = handler.event;
-      const pathFromEvent = (path) => R.pathOr(null, path, event);
-      const filtered =  R.map(pathFromEvent, options.filter);
+      const { event } = handler;
+      const pathFromEvent = path => R.pathOr(null, path, event);
+      const filtered = R.map(pathFromEvent, options.filter);
       options.logger(JSON.stringify(filtered));
 
-      // next();
+      next();
     },
   });
-
 };

--- a/src/requestLoggerMiddleware.js
+++ b/src/requestLoggerMiddleware.js
@@ -13,7 +13,9 @@ export default (config) => {
       sourceIp: ['requestContext', 'identity', 'sourceIp'],
       userAgent: ['requestContext', 'identity', 'userAgent'],
       awsRequestId: ['awsRequestId'],
+      stage: ['requestContext', 'stage'],
     },
+    modifier: result => result,
   };
 
   const options = Object.assign({}, defaults, config);
@@ -23,7 +25,7 @@ export default (config) => {
       const { event } = handler;
       const pathFromEvent = path => R.pathOr(null, path, event);
       const filtered = R.map(pathFromEvent, options.filter);
-      options.logger(JSON.stringify(filtered));
+      options.logger(JSON.stringify(options.modifier(filtered)));
 
       next();
     },

--- a/src/requestLoggerMiddleware.js
+++ b/src/requestLoggerMiddleware.js
@@ -1,0 +1,33 @@
+import * as R from 'ramda';
+
+export default (config) => {
+
+  const defaults = {
+    logger: console.log,
+    filter: {
+      resource: ['resource'],
+      httpMethod: ['httpMethod'],
+      queryStringParameters: ['queryStringParameters'],
+      pathParameters: ['pathParameters'],
+      headers: ['headers'],
+      body: ['body'],
+      sourceIp: ['requestContext', 'identity', 'sourceIp'],
+      userAgent: ['requestContext', 'identity', 'userAgent'],
+      awsRequestId: ['awsRequestId'],
+    },
+  };
+
+  const options = Object.assign({}, defaults, config);
+
+  return ({
+    before: (handler, next) => {
+      const event = handler.event;
+      const pathFromEvent = (path) => R.pathOr(null, path, event);
+      const filtered =  R.map(pathFromEvent, options.filter);
+      options.logger(JSON.stringify(filtered));
+
+      // next();
+    },
+  });
+
+};

--- a/tests/requestLoggerMiddleware.js
+++ b/tests/requestLoggerMiddleware.js
@@ -1,0 +1,63 @@
+import {describe} from 'mocha';
+import sinon from 'sinon';
+import expect from 'unexpected';
+import requestLoggerMiddleware from '../src/requestLoggerMiddleware';
+
+const handler = {
+  event: {
+    "httpMethod": "GET",
+    "body": "{\"name\": \"Sam\"}",
+    "path": "/users",
+    "resource": "/{proxy+}",
+    "queryStringParameters": {},
+    "pathParameters": {
+      "proxy": "users"
+    },
+    "headers": {
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+      "Accept-Encoding": "gzip, deflate, sdch, br",
+      "Accept-Language": "en-US,en;q=0.8",
+      "Content-Type": "application/json",
+      "Host": "xxxxxxxxxx.execute-api.us-east-1.amazonaws.com",
+    },
+    "requestContext": {
+      "accountId": "111111111111",
+        "resourceId": "xxxxxx",
+        "stage": "prod",
+        "requestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "identity": {
+        "cognitoIdentityPoolId": "",
+          "accountId": "",
+          "cognitoIdentityId": "",
+          "caller": "",
+          "apiKey": "",
+          "sourceIp": "11.111.111.111",
+          "cognitoAuthenticationType": "",
+          "cognitoAuthenticationProvider": "",
+          "userArn": "",
+          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36",
+          "user": ""
+      },
+      "resourcePath": "/{proxy+}",
+      "httpMethod": "GET",
+      "apiId": "xxxxxxxxxx"
+    }
+  }
+};
+
+describe('requestLoggerMiddleware', () => {
+
+  beforeEach(() => {
+    sinon.stub(console, 'log');
+  });
+
+  it('before', async () => {
+
+    const requestLogger = requestLoggerMiddleware();
+
+    requestLogger.before(handler);
+
+    expect(console.log.calledOnce, 'to be true');
+    expect(console.log.calledWith('{"resource":"/{proxy+}","httpMethod":"GET","queryStringParameters":{},"pathParameters":{"proxy":"users"},"headers":{"Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8","Accept-Encoding":"gzip, deflate, sdch, br","Accept-Language":"en-US,en;q=0.8","Content-Type":"application/json","Host":"xxxxxxxxxx.execute-api.us-east-1.amazonaws.com"},"body":"{\\"name\\": \\"Sam\\"}","sourceIp":"11.111.111.111","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36","awsRequestId":null}'), 'to be true');
+  });
+});

--- a/tests/requestLoggerMiddleware.js
+++ b/tests/requestLoggerMiddleware.js
@@ -1,61 +1,59 @@
-import {describe} from 'mocha';
+import { describe } from 'mocha';
 import sinon from 'sinon';
 import expect from 'unexpected';
 import requestLoggerMiddleware from '../src/requestLoggerMiddleware';
 
 const handler = {
   event: {
-    "httpMethod": "GET",
-    "body": "{\"name\": \"Sam\"}",
-    "path": "/users",
-    "resource": "/{proxy+}",
-    "queryStringParameters": {},
-    "pathParameters": {
-      "proxy": "users"
+    httpMethod: 'GET',
+    body: '{"name": "Sam"}',
+    path: '/users',
+    resource: '/{proxy+}',
+    queryStringParameters: {},
+    pathParameters: {
+      proxy: 'users',
     },
-    "headers": {
-      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-      "Accept-Encoding": "gzip, deflate, sdch, br",
-      "Accept-Language": "en-US,en;q=0.8",
-      "Content-Type": "application/json",
-      "Host": "xxxxxxxxxx.execute-api.us-east-1.amazonaws.com",
+    headers: {
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+      'Accept-Encoding': 'gzip, deflate, sdch, br',
+      'Accept-Language': 'en-US,en;q=0.8',
+      'Content-Type': 'application/json',
+      Host: 'xxxxxxxxxx.execute-api.us-east-1.amazonaws.com',
     },
-    "requestContext": {
-      "accountId": "111111111111",
-        "resourceId": "xxxxxx",
-        "stage": "prod",
-        "requestId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "identity": {
-        "cognitoIdentityPoolId": "",
-          "accountId": "",
-          "cognitoIdentityId": "",
-          "caller": "",
-          "apiKey": "",
-          "sourceIp": "11.111.111.111",
-          "cognitoAuthenticationType": "",
-          "cognitoAuthenticationProvider": "",
-          "userArn": "",
-          "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36",
-          "user": ""
+    requestContext: {
+      accountId: '111111111111',
+      resourceId: 'xxxxxx',
+      stage: 'prod',
+      requestId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+      identity: {
+        cognitoIdentityPoolId: '',
+        accountId: '',
+        cognitoIdentityId: '',
+        caller: '',
+        apiKey: '',
+        sourceIp: '11.111.111.111',
+        cognitoAuthenticationType: '',
+        cognitoAuthenticationProvider: '',
+        userArn: '',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36',
+        user: '',
       },
-      "resourcePath": "/{proxy+}",
-      "httpMethod": "GET",
-      "apiId": "xxxxxxxxxx"
-    }
-  }
+      resourcePath: '/{proxy+}',
+      httpMethod: 'GET',
+      apiId: 'xxxxxxxxxx',
+    },
+  },
 };
 
 describe('requestLoggerMiddleware', () => {
-
   beforeEach(() => {
     sinon.stub(console, 'log');
   });
 
   it('before', async () => {
-
     const requestLogger = requestLoggerMiddleware();
 
-    requestLogger.before(handler);
+    requestLogger.before(handler, () => {});
 
     expect(console.log.calledOnce, 'to be true');
     expect(console.log.calledWith('{"resource":"/{proxy+}","httpMethod":"GET","queryStringParameters":{},"pathParameters":{"proxy":"users"},"headers":{"Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8","Accept-Encoding":"gzip, deflate, sdch, br","Accept-Language":"en-US,en;q=0.8","Content-Type":"application/json","Host":"xxxxxxxxxx.execute-api.us-east-1.amazonaws.com"},"body":"{\\"name\\": \\"Sam\\"}","sourceIp":"11.111.111.111","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36","awsRequestId":null}'), 'to be true');

--- a/tests/requestLoggerMiddleware.js
+++ b/tests/requestLoggerMiddleware.js
@@ -45,6 +45,27 @@ const handler = {
   },
 };
 
+const expectedOutput = {
+  resource: '/{proxy+}',
+  httpMethod: 'GET',
+  queryStringParameters: {},
+  pathParameters: {
+    proxy: 'users',
+  },
+  headers: {
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+    'Accept-Encoding': 'gzip, deflate, sdch, br',
+    'Accept-Language': 'en-US,en;q=0.8',
+    'Content-Type': 'application/json',
+    Host: 'xxxxxxxxxx.execute-api.us-east-1.amazonaws.com',
+  },
+  body: '{"name": "Sam"}',
+  sourceIp: '11.111.111.111',
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36',
+  awsRequestId: null,
+  stage: 'prod',
+};
+
 describe('requestLoggerMiddleware', () => {
   beforeEach(() => {
     sinon.stub(console, 'log');
@@ -56,6 +77,6 @@ describe('requestLoggerMiddleware', () => {
     requestLogger.before(handler, () => {});
 
     expect(console.log.calledOnce, 'to be true');
-    expect(console.log.calledWith('{"resource":"/{proxy+}","httpMethod":"GET","queryStringParameters":{},"pathParameters":{"proxy":"users"},"headers":{"Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8","Accept-Encoding":"gzip, deflate, sdch, br","Accept-Language":"en-US,en;q=0.8","Content-Type":"application/json","Host":"xxxxxxxxxx.execute-api.us-east-1.amazonaws.com"},"body":"{\\"name\\": \\"Sam\\"}","sourceIp":"11.111.111.111","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36","awsRequestId":null}'), 'to be true');
+    expect(console.log.calledWith(JSON.stringify(expectedOutput)), 'to be true');
   });
 });


### PR DESCRIPTION
Mam prvy vykop tohto loggeru, vychadza z https://github.com/keboola/oauth-api/issues/166.

Akurat som to chcel spravit hodne obecne, aby to mohlo byt public.

Takze to logovanie veci ako ID projektu, tokenu atd by som riesil tak, ze v `options` tohto loggeru je `modifier`, co je nieco ako callback funkcia, ktorej sa predaju vyfilitrovane hodnoty z request eventu.
A mozes ich upravit. Napriklad, ze zahviezdickujes token v hlavicke.

Ale bolo by mozne do toho callbacku nacpat aj volanie "verifyToken" a z toho vybrat ownera a projekt id.

Jedina nevyhoda toho je, ze ten "verifyToken" sa bude musiet volat zrejme viackrat v tej apke. Alebo ono zrejme ide predat nejake hodnoty do dalsieho "middlewaru" ale to neviem presne ako funguje..